### PR TITLE
Fix: explicitly declare reply

### DIFF
--- a/lib/fmt.zsh
+++ b/lib/fmt.zsh
@@ -15,6 +15,8 @@ ${1:-ls-color}::fmt(){
 	zparseopts -D {0,o,a,A}=opt_out {f,F}:=opt_format
 	case $opt_out in
 		-o|-0) local -a reply ;;
+		-a) typeset -ga reply ;;
+		-A) typeset -gA reply ;;
 	esac
 
 	# lookup list-colors for the current context


### PR DESCRIPTION
This PR fix following bug:

```zsh
❯ source ls-colors.zsh '' fmt
❯ typeset -ga reply; ls-color::fmt -A -F "%F%f%r%(h.%I%i. -> %L%l%r)" :completion:whatever /bin/sh; echo $reply
ls-color::fmt:112: bad math expression: operand expected at `/bin/sh'
❯ typeset -gA reply; ls-color::fmt -a -F "%F%f%r%(h.%I%i. -> %L%l%r)" :completion:whatever /bin/sh; echo $reply
ls-color::fmt:113: bad set of key/value pairs for associative array
```